### PR TITLE
Feature: ERC721Enumerable truffle test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "firebase-admin": "^9.4.2",
         "openzeppelin-solidity": "^2.2.0",
         "request-promise": "^4.2.6",
+        "truffle-assertions": "^0.9.2",
         "tslib": "^2.0.3",
         "web3": "^1.3.1"
       }
@@ -1370,6 +1371,14 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/async": {
@@ -4160,6 +4169,11 @@
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
     },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
@@ -5633,6 +5647,15 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/truffle-assertions": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/truffle-assertions/-/truffle-assertions-0.9.2.tgz",
+      "integrity": "sha512-9g2RhaxU2F8DeWhqoGQvL/bV8QVoSnQ6PY+ZPvYRP5eF7+/8LExb4mjLx/FeliLTjc3Tv1SABG05Gu5qQ/ErmA==",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "lodash.isequal": "^4.5.0"
       }
     },
     "node_modules/tslib": {
@@ -7646,6 +7669,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
     },
     "async": {
       "version": "2.6.3",
@@ -10112,6 +10140,11 @@
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
     },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
     "lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
@@ -11354,6 +11387,15 @@
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
+      }
+    },
+    "truffle-assertions": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/truffle-assertions/-/truffle-assertions-0.9.2.tgz",
+      "integrity": "sha512-9g2RhaxU2F8DeWhqoGQvL/bV8QVoSnQ6PY+ZPvYRP5eF7+/8LExb4mjLx/FeliLTjc3Tv1SABG05Gu5qQ/ErmA==",
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "lodash.isequal": "^4.5.0"
       }
     },
     "tslib": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "scripts": {
     "test": "truffle test",
-    "compile": "truffle compile"
+    "compile": "truffle compile",
+    "start-ganache": "ganache-cli -p 7545"
   },
   "repository": {
     "type": "git",

--- a/test/ERC721Enumerable.spec.js
+++ b/test/ERC721Enumerable.spec.js
@@ -7,10 +7,10 @@ contract('ERC721Mintable', (accounts) => {
     describe('ERC721Mintable Enumerable methods test', () => {
 
         beforeEach(async () => {
-            this.contract = await ERC721Mintable.new({ from: account_one })
-            await this.contract.mint(account_one, 1, { from: account_one})
-            await this.contract.mint(account_one, 2, { from: account_one })
-            await this.contract.mint(account_one, 3, { from: account_one })
+            this.contract = await ERC721Mintable.new({ from: account_one });
+            await this.contract.mint(account_one, 1, { from: account_one});
+            await this.contract.mint(account_one, 2, { from: account_one });
+            await this.contract.mint(account_one, 3, { from: account_one });
         });
 
         it('should return the total amount of tokens stored by the contract', async () => {
@@ -18,21 +18,23 @@ contract('ERC721Mintable', (accounts) => {
             assert.equal(totalSupply, 3, 'Invalid total supply');
         })
 
-        it('should return  token ID at the given index of the specified owner', async () => {
+        it('should return the token ID at the given index of the specified owner', async () => {
             const owner = account_one;
             let index = 0;
-            let token = await this.contract.tokenOfOwnerByIndex(owner, index);
-            assert.equal(token, 1, 'Invalid tokenId');
+            let tokenId = await this.contract.tokenOfOwnerByIndex(owner, index);
+            assert.equal(tokenId, 1, 'Invalid tokenId');
             index = 1;
-            token = await this.contract.tokenOfOwnerByIndex(owner, index);
-            assert.equal(token, 2, 'Invalid tokenId');
+            tokenId = await this.contract.tokenOfOwnerByIndex(owner, index);
+            assert.equal(tokenId, 2, 'Invalid tokenId');
             index = 2;
-            token = await this.contract.tokenOfOwnerByIndex(owner, index);
-            assert.equal(token, 3, 'Invalid tokenId');
+            tokenId = await this.contract.tokenOfOwnerByIndex(owner, index);
+            assert.equal(tokenId, 3, 'Invalid tokenId');
         })
 
-        it('should get token balance', async () => {
-
+        it('should return the token ID at the given index of all tokens in this contract', async () => {
+            let index = 0;
+            let tokenId = await this.contract.tokenByIndex(index);
+            assert.equal(tokenId, 1, 'Invalid tokenId');
         })
 
         it('should return token uri', async () => {

--- a/test/ERC721Enumerable.spec.js
+++ b/test/ERC721Enumerable.spec.js
@@ -2,8 +2,7 @@ const ERC721Mintable = artifacts.require('ERC721Mintable')
 
 contract('ERC721Mintable', (accounts) => {
     const account_one = accounts[0]
-    const account_two = accounts[1]
-//ERC721Enumerable ERC721Metadata ERC721Mintable
+
     describe('ERC721Mintable Enumerable methods test', () => {
 
         beforeEach(async () => {
@@ -12,6 +11,12 @@ contract('ERC721Mintable', (accounts) => {
             await this.contract.mint(account_one, 2, { from: account_one });
             await this.contract.mint(account_one, 3, { from: account_one });
         });
+
+        it('should support ERC721Enumerable interface', async () => {
+            const ERC721_ENUMERABLE_INTERFACE_ID = '0x780e9d63';
+            const isSupported = await this.contract.supportsInterface(ERC721_ENUMERABLE_INTERFACE_ID);
+            assert.equal(isSupported, true, 'Must be supported');
+        })
 
         it('should return the total amount of tokens stored by the contract', async () => {
             const totalSupply = await this.contract.totalSupply();
@@ -36,14 +41,5 @@ contract('ERC721Mintable', (accounts) => {
             let tokenId = await this.contract.tokenByIndex(index);
             assert.equal(tokenId, 1, 'Invalid tokenId');
         })
-
-        it('should return token uri', async () => {
-
-        })
-
-        it('should transfer token from one owner to another', async () => {
-
-        })
-
     })
 })

--- a/test/ERC721Enumerable.spec.js
+++ b/test/ERC721Enumerable.spec.js
@@ -1,0 +1,47 @@
+const ERC721Mintable = artifacts.require('ERC721Mintable')
+
+contract('ERC721Mintable', (accounts) => {
+    const account_one = accounts[0]
+    const account_two = accounts[1]
+//ERC721Enumerable ERC721Metadata ERC721Mintable
+    describe('ERC721Mintable Enumerable methods test', () => {
+
+        beforeEach(async () => {
+            this.contract = await ERC721Mintable.new({ from: account_one })
+            await this.contract.mint(account_one, 1, { from: account_one})
+            await this.contract.mint(account_one, 2, { from: account_one })
+            await this.contract.mint(account_one, 3, { from: account_one })
+        });
+
+        it('should return the total amount of tokens stored by the contract', async () => {
+            const totalSupply = await this.contract.totalSupply();
+            assert.equal(totalSupply, 3, 'Invalid total supply');
+        })
+
+        it('should return  token ID at the given index of the specified owner', async () => {
+            const owner = account_one;
+            let index = 0;
+            let token = await this.contract.tokenOfOwnerByIndex(owner, index);
+            assert.equal(token, 1, 'Invalid tokenId');
+            index = 1;
+            token = await this.contract.tokenOfOwnerByIndex(owner, index);
+            assert.equal(token, 2, 'Invalid tokenId');
+            index = 2;
+            token = await this.contract.tokenOfOwnerByIndex(owner, index);
+            assert.equal(token, 3, 'Invalid tokenId');
+        })
+
+        it('should get token balance', async () => {
+
+        })
+
+        it('should return token uri', async () => {
+
+        })
+
+        it('should transfer token from one owner to another', async () => {
+
+        })
+
+    })
+})


### PR DESCRIPTION
Hey, 

Why is this change neccesary?
This commit adds the first approximation of the test suite for the
Enumerable Contract implementation for ERC721.

How does it address the issue?
By adding the test suite.

What side effects does this change have?
None. It's the first version of the test suite for the contract.